### PR TITLE
fix: 扫码登陆

### DIFF
--- a/model/mys/mysTool.js
+++ b/model/mys/mysTool.js
@@ -15,7 +15,7 @@ const hk4_sdk = `https://hk4e-sdk.mihoyo.com`;
 const bbs_api = `https://bbs-api.mihoyo.com`;
 const cloud_api = `https://api-cloudgame.mihoyo.com`
 const pass_api = `https://passport-api.mihoyo.com`
-const app_id = 4
+const app_id = 8
 const publicKey = `-----BEGIN PUBLIC KEY-----
 MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDDvekdPMHN3AYhm/vktJT+YJr7cI5DcsNKqdsx5DZX0gDuWFuIjzdwButrIYPNmRJ1G8ybDIF7oDW2eEpm5sMbL9zs
 9ExXCdvqrn51qELbqj0XxtMTIpaCHFSI50PfPpTFV9Xt/hmyVwokoOXFlAEgCn+Q


### PR DESCRIPTION
已经是第二次抽风，之前就出现过一次，传递的原神的app_id就会扫码失败，使用其他app_id可以暂时修复这个问题

参考: [qrcode_hk4e.md](https://github.com/UIGF-org/mihoyo-api-collect/blob/main/hoyolab/login/qrcode_hk4e.md#%E7%94%9F%E6%88%90%E4%BA%8C%E7%BB%B4%E7%A0%81)